### PR TITLE
Fix typo: select * from t1 -> SELECT * FROM t1

### DIFF
--- a/chapter2/README.md
+++ b/chapter2/README.md
@@ -59,7 +59,7 @@ PostgreSQLの中では同じ行を更新したときに、違う行として書�
 ```
 testdb=# INSERT INTO t1 VALUES ( 101, 'insert 1' );
 INSERT 0 1
-testdb=# select * from t1;
+testdb=# SELECT * FROM t1;
  uid |  uname
 -----+----------
  101 | insert 1


### PR DESCRIPTION
第二章の SQL で1箇所だけ SELECT などが小文字になっている箇所が気になりましたので細かいですが pull request を出させて頂きました。
8章についてはすべて小文字で SQL の select などが記載されていたので変更していません。
よろしければご確認いただければと思います。
よろしくお願いいたします。